### PR TITLE
update to mirage 4.9 and add Qubes target

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -1,40 +1,17 @@
+(* mirage >= 4.9.0 & < 4.10.0 *)
 (* Copyright Robur, 2020 *)
 
 open Mirage
 
-type http_client = HTTP_client
-let http_client = typ HTTP_client
-
-let dns_upstream =
-  let doc = Key.Arg.info ~doc:"Upstream DNS resolver IP" ["dns-upstream"] in
-  Key.(create "dns-upstream" Arg.(opt (some ip_address) None doc))
-
-let dns_port =
-  let doc = Key.Arg.info ~doc:"Upstream DNS resolver port" ["dns-port"] in
-  Key.(create "dns-port" Arg.(opt int 53 doc))
-
-let tls_hostname =
-  let doc = Key.Arg.info ~doc:"Hostname to use for TLS authentication" ["tls-hostname"] in
-  Key.(create "tls-hostname" Arg.(opt (some string) None doc))
-
-let authenticator =
-  let doc = Key.Arg.info ~doc:"TLS authenticator" ["authenticator"] in
-  Key.(create "authenticator" Arg.(opt (some string) None doc))
-
-let no_tls =
-  let doc = Key.Arg.info ~doc:"Disable DNS-over-TLS" ["no-tls"] in
-  Key.(create "no-tls" Arg.(opt bool false doc))
-
-let blocklist_url =
-  let doc = Key.Arg.info ~doc:"URL to fetch the blocked list of domains from" ["blocklist-url"] in
-  Key.(create "blocklist-url" Arg.(opt (some string) None doc))
-
 let dnsvizor =
-  let packages =
+  main
+  ~packages:
     [
       package "logs" ;
       package "metrics" ;
       package ~min:"6.0.0" ~sublibs:["mirage"] "dns-stub";
+      package "mirage-ptime";
+      package "http-mirage-client";
       package "dns";
       package "dns-client";
       package "dns-mirage";
@@ -43,35 +20,30 @@ let dnsvizor =
       package "dns-server";
       package "ca-certs-nss";
       package "hex";
-      package ~pin:"git+https://git.robur.io/robur/http-mirage-client.git" "http-mirage-client";
     ]
-  in
-  foreign
-    ~keys:[Key.v dns_upstream ; Key.v dns_port ; Key.v tls_hostname ; Key.v authenticator ; Key.v no_tls; Key.v blocklist_url ]
-    ~packages
     "Unikernel.Main"
-    (random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> http_client @-> job)
+    (stackv4v6 @-> http_client @-> job)
 
 let http_client =
   let connect _ modname = function
-    | [ _pclock; _tcpv4v6; ctx ] ->
-      Fmt.str {ocaml|%s.connect %s|ocaml} modname ctx
-    | _ -> assert false in
+    | [ _tcpv4v6; ctx ] ->
+        code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname ctx
+    | _ -> assert false
+  in
   impl ~connect "Http_mirage_client.Make"
-    (pclock @-> tcpv4v6 @-> git_client @-> http_client)
+    (tcpv4v6 @-> mimic @-> Mirage.http_client)
 
-let stack = generic_stackv4v6 default_network
-let dns = generic_dns_client stack
-let tcp = tcpv4v6_of_stackv4v6 stack
-let happy_eyeballs = git_happy_eyeballs stack dns (generic_happy_eyeballs stack dns)
-let http_client = http_client $ default_posix_clock $ tcp $ happy_eyeballs
+let stackv4v6 = generic_stackv4v6 default_network
+let he = generic_happy_eyeballs stackv4v6
+let dns = generic_dns_client stackv4v6 he
+let tcp = tcpv4v6_of_stackv4v6 stackv4v6
+
+let http_client =
+  let happy_eyeballs = mimic_happy_eyeballs stackv4v6 he dns in
+  http_client $ tcp $ happy_eyeballs
 
 let () =
   register "mirage-hole" [
     dnsvizor
-    $ default_random
-    $ default_posix_clock
-    $ default_monotonic_clock
-    $ default_time
-    $ stack
+    $ stackv4v6
     $ http_client ]

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -116,22 +116,21 @@ module Main
           let tls = Tls.Config.client ~authenticator ?peer_name ?ip:ip' () in
           Some [ `Tls (tls, ip, if dns_port = 53 then 853 else dns_port) ]
     in
-    let url = blocklist_url in
-    Log.info (fun m -> m "downloading %s" url);
+    Log.info (fun m -> m "downloading %s" blocklist_url);
     let open Lwt.Infix in
     let* result = Http_mirage_client.request
        http_ctx
-       url
+       blocklist_url
        (fun resp _acc body ->
           if H2.Status.is_successful resp.status
           then
             begin
-              Logs.info (fun m -> m "downloaded %s" url);
+              Logs.info (fun m -> m "downloaded %s" blocklist_url);
               Lwt.return (parse_domain_file body)
             end
           else
             begin
-              Logs.warn (fun m -> m "%s: %a" url H2.Status.pp_hum resp.status);
+              Logs.warn (fun m -> m "%s: %a" blocklist_url H2.Status.pp_hum resp.status);
               Lwt.return ([])
             end
        )

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -49,7 +49,7 @@ module Main
   let ipv4_pair = (3600l,Ipaddr.V4.(Set.singleton localhost))
   let soa       = (Dns.Soa.create (Domain_name.of_string_exn "localhost"))
   let add_dns_entries str t =
-    Logs.warn (fun m -> m "adding domain: \"%s\"" str);
+    Logs.debug (fun m -> m "adding domain: \"%s\"" str);
     match Domain_name.of_string str with
     | Error (`Msg msg) -> (Logs.err (fun m -> m "Invalid domain name: %s" msg); t)
     | Ok name ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1,12 +1,13 @@
-open Cmdliner
-
-let src = Logs.Src.create "unikernel" ~doc:"Main unikernel code"
-module Log = (val Logs.src_log src : Logs.LOG)
 
 let argument_error = 64
 
 (* a default/fall-back blocking URL *)
 let url = "https://blocklistproject.github.io/Lists/tracking.txt"
+
+open Cmdliner
+
+let src = Logs.Src.create "unikernel" ~doc:"Main unikernel code"
+module Log = (val Logs.src_log src : Logs.LOG)
 
 let dns_upstream =
   let doc = Arg.info ~doc:"Upstream DNS resolver IP" ["dns-upstream"] in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -11,7 +11,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let dns_cache =
   let doc = Arg.info ~doc:"DNS cache size" ["dns-cache"] in
-  Mirage_runtime.register_arg Arg.(value & opt int 0 doc)
+  Mirage_runtime.register_arg Arg.(value & opt (some int) None doc)
 
 let blocklist_url =
   let doc = Arg.info ~doc:"URL to fetch the blocked list of domains from" ["blocklist-url"] in
@@ -19,7 +19,7 @@ let blocklist_url =
 
 let timeout =
   let doc = Arg.info ~doc:"Timeout value in ns" ["timeout"] in
-  Mirage_runtime.register_arg Arg.(value & opt int64 0L doc)
+  Mirage_runtime.register_arg Arg.(value & opt (some int64) None doc)
 
 module Main
     (S : Tcpip.Stack.V4V6)
@@ -99,7 +99,7 @@ module Main
     in
     (* setup stub forwarding state and IP listeners: *)
     Stub.H.connect_device s >>= fun happy_eyeballs ->
-    let _ = Stub.create ~cache_size ~timeout primary_t ~happy_eyeballs s in
+    let _ = Stub.create ?cache_size ?timeout primary_t ~happy_eyeballs s in
 
     (* Since {Stub.create} registers UDP + TCP listeners asynchronously there
        is no Lwt task.

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -76,6 +76,7 @@ module Main
 
   let start s http_ctx =
     let open Lwt.Syntax in
+    let open Lwt.Infix in
     let dns_upstream = dns_upstream () in
     let dns_port = dns_port () in
     let tls_hostname = tls_hostname () in
@@ -118,7 +119,6 @@ module Main
           Some [ `Tls (tls, ip, if dns_port = 53 then 853 else dns_port) ]
     in
     Log.info (fun m -> m "downloading %s" blocklist_url);
-    let open Lwt.Infix in
     let* result = Http_mirage_client.request
        http_ctx
        blocklist_url


### PR DESCRIPTION
Dear @jmid ,
This PR is mainly an update to the recent mirage 4.9 ecosystem. While I'm at it, I've tested with Qubes and it works fine as an AppVM, so I've added the instructions to the README.md file. And BTW I suppose it should also runs fine with the other solo5 targets :)
One thing I need to rule out is the type error at line 85 for the definition of `nameservers` that makes Stub.create unhappy. I'll try to update the PR soon (tm).
Please let me know if I also need to do something else :)
Best.