### PR TITLE
hex is currently not a dependency

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -42,7 +42,6 @@ let dnsvizor =
       package "dns-tsig";
       package "dns-server";
       package "ca-certs-nss";
-      package "hex";
       package ~pin:"git+https://git.robur.io/robur/http-mirage-client.git" "http-mirage-client";
     ]
   in


### PR DESCRIPTION
Dear @jmid , hex doesn't seem to be used anymore. It's probably not harmful to keep it in `config.ml`, nor useful. For the story behind, I'm trying to remove some Cstruct-BA dependencies and hex doesn't comply with that goal, so I can use this patch on my end if you'd rather keep it :)